### PR TITLE
Small update to attempt avoiding incorrect date adjustments.

### DIFF
--- a/DateCalculatedFieldsExternalModule.php
+++ b/DateCalculatedFieldsExternalModule.php
@@ -291,7 +291,7 @@ class DateCalculatedFieldsExternalModule extends AbstractExternalModule
         }
         else {
             //if ($currentEvent) {
-            $newDate = date_add($postDate, date_interval_create_from_date_string($daysOffset*24 . ' hours'));
+            $newDate = date_add($postDate, \DateInterval::createFromDateString((int)$daysOffset . ' days'));
             //}
         }
         return $newDate;


### PR DESCRIPTION
This is an alternative to an earlier change for PHP8. I believe it was attempting to avoid some errors by using multiplication to force conversion to integer values. It is better to keep things as days rather than risk incorrect conversions back and forth between days and hours.