### PR TITLE
Fix warning on PHP8 of missing array item.

### DIFF
--- a/DateCalculatedFieldsExternalModule.php
+++ b/DateCalculatedFieldsExternalModule.php
@@ -517,7 +517,7 @@ class DateCalculatedFieldsExternalModule extends AbstractExternalModule
 
             $sourceFieldForm = $project->metadata[$fieldName]['form_name'];
 
-            $sourceDate = ($recordData[$record_id]['repeat_instances'][$event_id][$sourceFieldForm][intval($instance) - 1][$fieldName] != "" ? $recordData[$record_id]['repeat_instances'][$event_id][$sourceFieldForm][intval($instance) - 1][$fieldName] : $recordData[$record_id][$event_id][$fieldName]);
+            $sourceDate = ($recordData[$record_id]['repeat_instances'][$event_id][$sourceFieldForm][intval($instance) - 1][$fieldName] ?? ($recordData[$record_id][$event_id][$fieldName] ?? ''));
             if (!$this->validateDate($sourceDate)) continue;
 
             $javaString .= "var instancedate = new Date('$sourceDate');";


### PR DESCRIPTION
# Pre-flight Checklist
- [*] Are all the features in this PR tested? 
- [*] Have other features this PR touches also been tested?
- [*] Has the code been formatted for consistency and readability?
- [*] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
Fixing issue with REDCap::getData sometimes not returning an array with a 'repeat_instances' section.

# Context
Solving a flood of warnings as shown below:

![image](https://github.com/user-attachments/assets/cb071336-680c-403e-a2b6-feb79dad34da)
